### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# for travis
-!.mvn/*
-
 # Compiled class file
 *.class
 
@@ -22,4 +19,12 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-/target/
+
+# ignore target folder
+/target/*
+
+# for travis
+!.mvn/*
+
+# jar file
+!/target/InciManager_i2b*.jar


### PR DESCRIPTION
Just removing the target directory from the repository (except our project .jar, which can be used by docker to build the image faster without having to download all the maven dependencies).