### PR TITLE
Fix gatling tests

### DIFF
--- a/src/test/gatling/ChatSimulation.scala
+++ b/src/test/gatling/ChatSimulation.scala
@@ -9,7 +9,7 @@ import io.gatling.jdbc.Predef._
 class ChatSimulation extends Simulation {
 
 	val httpProtocol = http
-		.baseURL("http://192.168.99.100:8081")
+		.baseURL("http://178.62.52.250:8081")
 		.inferHtmlResources()
 		.acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 		.acceptEncodingHeader("gzip, deflate")
@@ -19,11 +19,6 @@ class ChatSimulation extends Simulation {
 	val headers_0 = Map("Upgrade-Insecure-Requests" -> "1")
 
 	val headers_2 = Map("Accept" -> "text/css,*/*;q=0.1")
-
-	val headers_9 = Map(
-		"Accept" -> "*/*",
-		"Content-Type" -> "application/json; charset=utf-8",
-		"X-Requested-With" -> "XMLHttpRequest")
 
 	val scn = scenario("ChatSimulation")
 		.exec(http("Home")
@@ -48,8 +43,8 @@ class ChatSimulation extends Simulation {
 		.pause(40)
 		.exec(http("Post /incident/create")
 			.post("/incident/create")
-			.headers(headers_9)
-			.body(RawFileBody("ChatSimulation_0009_request.txt")))
+			.header("Content-Type", "application/json")
+			.body(RawFileBody("chat_request.json")).asJSON)
 
 	setUp(scn.inject(rampUsers(1000) over(60 seconds))).protocols(httpProtocol)
 }

--- a/src/test/gatling/FormSimulation.scala
+++ b/src/test/gatling/FormSimulation.scala
@@ -9,7 +9,7 @@ import io.gatling.jdbc.Predef._
 class FormSimulation extends Simulation {
 
 	val httpProtocol = http
-		.baseURL("http://192.168.99.100:8081")
+		.baseURL("http://178.62.52.250:8081")
 		.inferHtmlResources()
 		.acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 		.acceptEncodingHeader("gzip, deflate")
@@ -20,11 +20,6 @@ class FormSimulation extends Simulation {
 
 	val headers_8 = Map("Accept" -> "*/*")
 
-	val headers_9 = Map(
-		"Accept" -> "*/*",
-		"Content-Type" -> "application/json; charset=utf-8",
-		"X-Requested-With" -> "XMLHttpRequest")
-
 	val scn = scenario("FormSimulation")
 		.exec(http("Home")
 			.get("/")
@@ -34,11 +29,13 @@ class FormSimulation extends Simulation {
 		.pause(8)
 		.exec(http("Post agentform")
 			.post("/agentform")
+			.headers(headers_0)
 			.formParam("username", "sonny")
 			.formParam("password", "pass123")
 			.formParam("kind", "Person")
 			.resources(http("Resources /incidents ")
-			.get("/incidents")))
+			.get("/incidents")
+			.headers(headers_0)))
 		.pause(8)
 		.exec(http("Get incident form")
 			.get("/incident/create?method=form")
@@ -49,10 +46,8 @@ class FormSimulation extends Simulation {
 		.pause(45)
 		.exec(http("Post /incident/create")
 			.post("/incident/create")
-			.headers(headers_9)
-			.body(RawFileBody("FormSimulation_0009_request.txt"))
-			.resources(http("Resources /incident")
-			.get("/incidents")))
+			.header("Content-Type", "application/json")
+			.body(RawFileBody("form_request.json")).asJSON)
 
 	setUp(scn.inject(rampUsers(1000) over(60 seconds))).protocols(httpProtocol)
 }

--- a/src/test/gatling/chat_request.json
+++ b/src/test/gatling/chat_request.json
@@ -1,0 +1,23 @@
+{
+  "agent": {
+    "username": "sonny",
+    "password": "pass123",
+    "kind": "Person"
+  },
+  "inciName": "incidentName",
+  "location": {
+    "lat": 1,
+    "lon": 1
+  },
+  "tags": [
+    "tag1",
+    "tag2"
+  ],
+  "moreInfo": [
+    "moreInfo1",
+    "moreInfo2"
+  ],
+  "properties": {
+    
+  }
+}

--- a/src/test/gatling/form_request.json
+++ b/src/test/gatling/form_request.json
@@ -1,0 +1,19 @@
+{
+  "inciName": "prueba",
+  "agent": {
+    "username": "sonny",
+    "password": "pass123",
+    "kind": "Person"
+  },
+  "location": {
+    "lat": 12,
+    "lon": 34
+  },
+  "tags": [
+    "emergency"
+  ],
+  "moreInfo": [
+    "aprox time 18:00"
+  ],
+  "properties": {}
+}


### PR DESCRIPTION
There was a problem with the request files used to test POST requests to "/incident/create". In this files the location was written as a String literal instead of as a double, so we were getting some errors from Java because it couldn't cast the String to Double, and therefore we were getting some KO requests from gatling. Now everything should work fine.